### PR TITLE
すべての要素を一括でFetchできるようにする

### DIFF
--- a/view/src/App.vue
+++ b/view/src/App.vue
@@ -2,6 +2,9 @@
   <main>
     <header>PProtein ⚙ Manage Panel</header>
     <nav>
+      <router-link to="/" custom v-slot="{ navigate, isActive }">
+        <div :class="{ active: isActive }" @click="navigate">Top</div>
+      </router-link>
       <router-link to="/pprof/" custom v-slot="{ navigate, isActive }">
         <div :class="{ active: isActive }" @click="navigate">PProf</div>
       </router-link>
@@ -51,6 +54,22 @@ nav {
 }
 section {
   padding: 1em 2em;
+}
+
+button {
+  padding: 0.4em 1em;
+  background-color: white;
+  border: 1px solid lightgray;
+  cursor: pointer;
+
+  &:hover {
+    border-color: orangered;
+  }
+
+  &:active {
+    color: white;
+    background-color: orangered;
+  }
 }
 </style>
 

--- a/view/src/components/EntriesTable.vue
+++ b/view/src/components/EntriesTable.vue
@@ -1,0 +1,78 @@
+<template>
+  <table>
+    <thead>
+    <tr>
+      <th>Open</th>
+      <th>Datetime</th>
+      <th>Source URL</th>
+      <th>Duration</th>
+      <th>Status</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr :key="info.Entry.ID" v-for="info in $props.entries">
+      <td>
+        <router-link v-if="info.Status == `ok`" :to="`${$props.prefix ? $props.prefix : '.'}/${info.Entry.ID}/`">Open</router-link>
+      </td>
+      <td>{{ info.Entry.Datetime.toLocaleString() }}</td>
+      <td>{{ info.Entry.URL }}</td>
+      <td>{{ info.Entry.Duration }}</td>
+      <td>
+        <div :class="`cell ${info.Status}`"></div>
+        {{ info.Message || info.Status }}
+      </td>
+    </tr>
+    </tbody>
+  </table>
+</template>
+
+<style scoped lang="scss">
+table {
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 0.5em 2em;
+  border: 1px solid #999;
+}
+
+.cell {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border-radius: 0.2em;
+  top: 0.1em;
+  position: relative;
+
+  &.ok {
+    background-color: blue;
+  }
+  &.fail {
+    background-color: red;
+  }
+  &.pending {
+    background-color: orange;
+    animation: flash 1s ease-in-out 0s infinite alternate;
+  }
+}
+
+@keyframes flash {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.1;
+  }
+}
+</style>
+
+<script lang="ts">
+export default {
+  name: 'EntriesTable',
+  props: {
+    prefix: String,
+    entries: Array,
+  },
+}
+</script>

--- a/view/src/components/EntryList.vue
+++ b/view/src/components/EntryList.vue
@@ -1,44 +1,7 @@
 <template>
   <section>
-    <div class="form">
-      <label>
-        Source URL<br />
-        <input type="text" size="50" v-model="$data.url" />
-      </label>
-      <label>
-        Duration<br />
-        <input type="number" size="10" v-model.number="$data.duration" />
-      </label>
-      <label>
-        &nbsp;<br />
-        <button @click="fetch">Fetch</button>
-      </label>
-    </div>
-    <table>
-      <thead>
-        <tr>
-          <th>Open</th>
-          <th>Datetime</th>
-          <th>Source URL</th>
-          <th>Duration</th>
-          <th>Status</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr :key="info.Entry.ID" v-for="info in $store.state.remote[$props.endpoint]">
-          <td>
-            <router-link v-if="info.Status == `ok`" :to="`./${info.Entry.ID}/`">Open</router-link>
-          </td>
-          <td>{{ info.Entry.Datetime.toLocaleString() }}</td>
-          <td>{{ info.Entry.URL }}</td>
-          <td>{{ info.Entry.Duration }}</td>
-          <td>
-            <div :class="`cell ${info.Status}`"></div>
-            {{ info.Message || info.Status }}
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <PproteinForm :endpoint="$props.endpoint" @fetch="update"/>
+    <EntriesTable :endpoint="$props.endpoint" :entries="$store.state.remote[$props.endpoint]"/>
   </section>
 </template>
 
@@ -46,109 +9,29 @@
 section {
   margin: 2em;
 }
-
-.form {
-  display: flex;
-  margin-bottom: 2em;
-  label {
-    margin-right: 1em;
-    &:focus-within {
-      color: orangered;
-    }
-    input {
-      border: 1px solid lightgray;
-      padding: 0.4em 1em;
-      &:focus {
-        border-color: orangered;
-        outline: 0;
-      }
-    }
-    button {
-      padding: 0.4em 1em;
-      background-color: white;
-      border: 1px solid lightgray;
-      cursor: pointer;
-      &:hover {
-        border-color: orangered;
-      }
-      &:active {
-        color: white;
-        background-color: orangered;
-      }
-    }
-  }
-}
-
-table {
-  border-collapse: collapse;
-}
-th,
-td {
-  padding: 0.5em 2em;
-  border: 1px solid #999;
-}
-.cell {
-  display: inline-block;
-  width: 1em;
-  height: 1em;
-  border-radius: 0.2em;
-  top: 0.1em;
-  position: relative;
-
-  &.ok {
-    background-color: blue;
-  }
-  &.fail {
-    background-color: red;
-  }
-  &.pending {
-    background-color: orange;
-    animation: flash 1s ease-in-out 0s infinite alternate;
-  }
-}
-@keyframes flash {
-  0% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0.1;
-  }
-}
 </style>
 
 <script lang="ts">
 import { defineComponent } from "vue";
+import PproteinForm from "./PproteinForm.vue";
+import EntriesTable from "./EntriesTable.vue";
 
 export default defineComponent({
+  components: {
+    EntriesTable,
+    PproteinForm
+  },
   props: {
     endpoint: String,
   },
   data() {
     return {
-      url: localStorage.getItem(`url[${this.$props.endpoint}]`) || "http://",
-      duration: localStorage.getItem(`duration[${this.$props.endpoint}]`) || 60,
       timer: -1,
     };
-  },
-  watch: {
-    url(val) {
-      localStorage.setItem(`url[${this.$props.endpoint}]`, val);
-    },
-    duration(val) {
-      localStorage.setItem(`duration[${this.$props.endpoint}]`, val);
-    },
   },
   methods: {
     async update() {
       await this.$store.dispatch("syncStoreData", { endpoint: this.$props.endpoint });
-    },
-    async fetch() {
-      await this.$store.dispatch("postStoreData", {
-        endpoint: this.$props.endpoint,
-        URL: this.$data.url,
-        Duration: parseInt(this.$data.duration),
-      });
-      await this.update();
     },
   },
   async beforeMount() {

--- a/view/src/components/Index.vue
+++ b/view/src/components/Index.vue
@@ -1,0 +1,82 @@
+<template>
+  <section>
+    <div class="container">
+      <h2>PProf</h2>
+      <PproteinForm ref="pprof" endpoint="pprof/profiles"/>
+      <EntriesTable
+          v-if="$store.state.remote['pprof/profiles']?.length > 0"
+          prefix="/pprof"
+          :entries="[$store.state.remote['pprof/profiles'][0]]"
+      />
+    </div>
+    <div class="container">
+      <h2>HTTP log</h2>
+      <PproteinForm ref="httplog" endpoint="httplog/logs"/>
+      <EntriesTable
+          v-if="$store.state.remote['httplog/logs']?.length > 0"
+          prefix="/httplog"
+          :entries="[$store.state.remote['httplog/logs'][0]]"
+      />
+    </div>
+    <div class="container">
+      <h2>MySQL slow log</h2>
+      <PproteinForm ref="slowlog" endpoint="slowlog/logs"/>
+      <EntriesTable
+          v-if="$store.state.remote['slowlog/logs']?.length > 0"
+          prefix="/slowlog"
+          :entries="[$store.state.remote['slowlog/logs'][0]]"
+      />
+    </div>
+    <div class="container right">
+      <button @click="updateState">Update State</button>
+      <button @click="fetchAll">Fetch All</button>
+    </div>
+  </section>
+</template>
+
+<style scoped lang="scss">
+section {
+  margin: 2em;
+}
+
+.container {
+  margin-bottom: 2em;
+}
+
+.right {
+  text-align: right;
+  button {
+    margin-left: 1em;
+  }
+}
+</style>
+
+<script lang="ts">
+import {defineComponent} from "vue";
+import PproteinForm from "./PproteinForm.vue";
+import EntriesTable from "./EntriesTable.vue";
+
+export default defineComponent({
+  components: {EntriesTable, PproteinForm},
+  methods: {
+    async fetchAll() {
+      await Promise.all([
+        this.$refs.pprof.fetch(),
+        this.$refs.httplog.fetch(),
+        this.$refs.slowlog.fetch(),
+      ]);
+      await this.updateState();
+    },
+    async updateState() {
+      await Promise.all([
+        this.$store.dispatch("syncStoreData", { endpoint: "pprof/profiles" }),
+        this.$store.dispatch("syncStoreData", { endpoint: "httplog/logs" }),
+        this.$store.dispatch("syncStoreData", { endpoint: "slowlog/logs" }),
+      ]);
+    }
+  },
+  async beforeMount() {
+    await this.updateState();
+  },
+});
+</script>

--- a/view/src/components/PproteinForm.vue
+++ b/view/src/components/PproteinForm.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="form">
+    <label>
+      Source URL<br/>
+      <input type="text" size="50" v-model="$data.url"/>
+    </label>
+    <label>
+      Duration<br/>
+      <input type="number" size="10" v-model.number="$data.duration"/>
+    </label>
+    <label>
+      &nbsp;<br/>
+      <button @click="fetch">Fetch</button>
+    </label>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.form {
+  display: flex;
+  margin-bottom: 2em;
+
+  label {
+    margin-right: 1em;
+
+    &:focus-within {
+      color: orangered;
+    }
+
+    input {
+      border: 1px solid lightgray;
+      padding: 0.4em 1em;
+
+      &:focus {
+        border-color: orangered;
+        outline: 0;
+      }
+    }
+
+  }
+}
+</style>
+
+<script lang="ts">
+export default {
+  name: 'PproteinForm',
+  props: {
+    endpoint: String
+  },
+  data() {
+    return {
+      url: localStorage.getItem(`url[${this.$props.endpoint}]`) || "http://",
+      duration: localStorage.getItem(`duration[${this.$props.endpoint}]`) || 60,
+    };
+  },
+  methods: {
+    async fetch() {
+      await this.$store.dispatch("postStoreData", {
+        endpoint: this.$props.endpoint,
+        URL: this.$data.url,
+        Duration: parseInt(this.$data.duration),
+      });
+      this.$emit("fetch");
+    },
+  },
+  watch: {
+    url(val) {
+      localStorage.setItem(`url[${this.$props.endpoint}]`, val);
+    },
+    duration(val) {
+      localStorage.setItem(`duration[${this.$props.endpoint}]`, val);
+    },
+  },
+}
+</script>

--- a/view/src/router.ts
+++ b/view/src/router.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHashHistory } from "vue-router";
 
+import Index from "./components/Index.vue";
 import PProfList from "./components/PProfList.vue";
 import PProfEntry from "./components/PProfEntry.vue";
 import HttpLogList from "./components/HttpLogList.vue";
@@ -12,7 +13,10 @@ export default createRouter({
 	routes: [
 		{
 			path: "/",
-			redirect: "/pprof/"
+            component: Index,
+			meta: {
+				title: "Top",
+			},
 		},
 		{
 			path: "/pprof/",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19851537/129534287-92be1a3d-1c92-400e-8ed9-744b9b1820d1.png)

トップページを作って一括で3つともFetchを開始できるようにしました。
また、各リストの最新の1つをトップページから見られるようにしました。
実装的にはFetch開始のAPIをクライアントから3つ叩いてるだけです。
2秒毎にリストのAPI叩くのもあれかなと思ったのでトップページではボタンを押さないとリストが更新されないようにしました。