### PR TITLE
slp v0.2.0に対応

### DIFF
--- a/internal/extproc/slp/processor.go
+++ b/internal/extproc/slp/processor.go
@@ -25,7 +25,7 @@ func (p *processor) Process(snapshot *collect.Snapshot) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("failed to find snapshot body: %w", err)
 	}
 
-	cmd := exec.Command("slp", "--config", p.confPath, "--output", "standard", "--format", "tsv", "--file", bodyPath)
+	cmd := exec.Command("slp", "my", "--config", p.confPath, "--output", "standard", "--format", "tsv", "--file", bodyPath)
 
 	res, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
[slp v0.2.0](https://github.com/tkuchiki/slp/releases/tag/v0.2.0) のPostgreSQL対応に伴い`slp` → `slp my`と変更が入ったことで、slowlogの分析が正常に動作しなくなっていたため修正しました。
当変更により暫定的にMySQLでは従来通り動作するようになっていますが、config等でPostgreSQL(`slp pg`)にも対応できるようにするかはお任せします。