### PR TITLE
同じ種類のタブ同士を切り替えたときに内容が更新されていなかった

### DIFF
--- a/view/src/components/HttpLogEntry.vue
+++ b/view/src/components/HttpLogEntry.vue
@@ -15,9 +15,17 @@ export default defineComponent({
       tsv: "",
     };
   },
-  async beforeCreate() {
-    const resp = await fetch(`/api/httplog/${this.$route.params.id}`);
-    this.tsv = await resp.text();
+  async created() {
+    await this.updateTsv(this.$route.params.id);
+  },
+  async beforeRouteUpdate(route) {
+    await this.updateTsv(route.params.id);
+  },
+  methods: {
+    async updateTsv(id: string | string[]) {
+      const resp = await fetch(`/api/httplog/${id}`);
+      this.tsv = await resp.text();
+    },
   },
 });
 </script>

--- a/view/src/components/MemoEntry.vue
+++ b/view/src/components/MemoEntry.vue
@@ -14,13 +14,21 @@ export default defineComponent({
       memo: { Text: null },
     };
   },
-  async beforeCreate() {
-    try {
-      const resp = await fetch(`/api/memo/${this.$route.params.id}`);
-      this.memo = await resp.json();
-    } catch (e) {
-      this.summary = `Error: ${e instanceof Error ? e.message : e}`;
-    }
+  async created() {
+    await this.updateMemo(this.$route.params.id);
+  },
+  async beforeRouteUpdate(route) {
+    await this.updateMemo(route.params.id);
+  },
+  methods: {
+    async updateMemo(id: string | string[]) {
+      try {
+        const resp = await fetch(`/api/memo/${id}`);
+        this.memo = await resp.json();
+      } catch (e) {
+        this.summary = `Error: ${e instanceof Error ? e.message : e}`;
+      }
+    },
   },
 });
 </script>

--- a/view/src/components/SlowLogEntry.vue
+++ b/view/src/components/SlowLogEntry.vue
@@ -15,9 +15,17 @@ export default defineComponent({
       tsv: "",
     };
   },
-  async beforeCreate() {
-    const resp = await fetch(`/api/slowlog/${this.$route.params.id}`);
-    this.tsv = await resp.text();
+  async created() {
+    await this.updateTsv(this.$route.params.id);
+  },
+  async beforeRouteUpdate(route) {
+    await this.updateTsv(route.params.id);
+  },
+  methods: {
+    async updateTsv(id: string | string[]) {
+      const resp = await fetch(`/api/slowlog/${id}`);
+      this.tsv = await resp.text();
+    },
   },
 });
 </script>


### PR DESCRIPTION
![image](https://github.com/kaz/pprotein/assets/49056869/a7408904-17b9-44a7-a4d3-e247d7c83847)
このようにslowlogが複数あって、その間を切り替えるとタブの内容が更新されていませんでした
このPRではこのバグを修正します。
同様のバグがhttplogとmemoでもありそうだったのでそちらも同様の変更を含めています。
