### PR TITLE
PPROTEIN_GIT_REPOSITORY配下だけでなく、その親ディレクトリも含めてgitレポジトリを探索するように修正

### DIFF
--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -17,7 +17,9 @@ type (
 )
 
 func GetInfo(repoDir string) (*RepositoryInfo, error) {
-	repo, err := git.PlainOpen(repoDir)
+	repo, err := git.PlainOpenWithOptions(repoDir, &git.PlainOpenOptions{
+		DetectDotGit: true,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to open git repo: %w", err)
 	}


### PR DESCRIPTION
現状、環境変数の`PPROTEIN_GIT_REPOSITORY`(デフォルト値はカレントディレクトリ`.`)で指定されたディレクトリ内に.gitがないか探索するようになっていますが、
カレントディレクトリ内だけではなく、その親ディレクトリも辿って.gitがないか探索した方が良いかなと思い修正しました。

大抵`/home/isucon`でgit initされるかと思いますが、アプリケーションが実行されるカレントディレクトリ(=`PPROTEIN_GIT_REPOSITORY`のデフォルト値)は`/home/isucon/src/webapp/golang`のように階層が掘られるため、PPROTEIN_GIT_REPOSITORYを`/home/isucon`に修正しないとgitのコミットハッシュを取得できません。
そこで親ディレクトリも含めて探索するようにすれば.gitを見つけることができるため、環境変数を追加する手間が減るかと思われます。

`PPROTEIN_GIT_REPOSITORY`がデフォルト値の場合のみ親ディレクトリも辿るオプションを入れるでも良いかもしれませんが、一旦常にONにするように修正しています