### PR TITLE
slp.yml の output が反映されない問題を解消

### DIFF
--- a/internal/extproc/slp/processor.go
+++ b/internal/extproc/slp/processor.go
@@ -25,7 +25,7 @@ func (p *processor) Process(snapshot *collect.Snapshot) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("failed to find snapshot body: %w", err)
 	}
 
-	cmd := exec.Command("slp", "my", "--config", p.confPath, "--output", "standard", "--format", "tsv", "--file", bodyPath)
+	cmd := exec.Command("slp", "my", "--config", p.confPath, "--format", "tsv", "--file", bodyPath)
 
 	res, err := cmd.Output()
 	if err != nil {

--- a/internal/extproc/slp/slp.yml
+++ b/internal/extproc/slp/slp.yml
@@ -2,3 +2,4 @@ bundle_values: true
 bundle_where_in: true
 filters: Query matches "^(SELECT|INSERT|UPDATE|REPLACE) "
 limit: 65536
+output: standard


### PR DESCRIPTION
`slp.yml` の `output` には表示するカラムを指定できますが、pprotein は `slp` コマンドを `--output` オプション付きで実行するため、設定ファイルに書いたものが上書きされます。
コマンド呼び出し時のオプションを削除することで、この問題を解消できます。